### PR TITLE
Clear localStorage when state version is updated

### DIFF
--- a/src/core/reducers/persist.js
+++ b/src/core/reducers/persist.js
@@ -3,9 +3,13 @@ import storage from 'redux-persist/lib/storage';
 import root from './root';
 
 const config = {
-	key: 'root',
+	version: 0,
 	storage,
+	key: 'root',
 	whitelist: ['gearPreview'],
+
+	// clear localStorage when version updated
+	migrate: () => ({}),
 };
 
 export default persistReducer(config, root);


### PR DESCRIPTION
Alternative (preferable) solution for #63. Instead of expiring after 24 hours, whenever the state version is updated, the localStorage will be cleared.

Closes #63 